### PR TITLE
'quadlets' in file path now indicates podman_network

### DIFF
--- a/src/parser/file-info.ts
+++ b/src/parser/file-info.ts
@@ -186,7 +186,7 @@ export function parseSystemdFilePath(filePath: string | undefined | null, enable
     if (type) return type;
 
     if (ext === "network") {
-        if (enablePodman && (filePath.includes("containers/") || filePath.includes("podman/")))
+        if (enablePodman && (filePath.includes("containers/") || filePath.includes("podman/") || filePath.includes("quadlets/")))
             return SystemdFileType.podman_network;
         return SystemdFileType.network;
     }


### PR DESCRIPTION
Currently, if a `*.network` file has a "containers" or "podman" parent directory it is considered a podman_network file instead of a regular network file.

This pull request adds "quadlets" to that list, allowing users to be more explicit in that it contains quadlet systemd files instead of legacy ones created by `podman generate systemd`.